### PR TITLE
Add index to XGB DataFrame

### DIFF
--- a/sklearn_pipeline_enhancements/model_specific/custom_transformers/transformers.py
+++ b/sklearn_pipeline_enhancements/model_specific/custom_transformers/transformers.py
@@ -15,7 +15,7 @@ class xgb_ModelTransformer(TransformerMixin):
         return self
 
     def transform(self, X, **transform_params):
-        return pd.DataFrame(self.model.predict(X), columns=[self.name + '_prediction'])
+        return pd.DataFrame(self.model.predict(X), index=X.index, columns=[self.name + '_prediction'])
 
 
 class xgb_y_log_transform_ModelTransformer(TransformerMixin):


### PR DESCRIPTION
Currently, the xgb_transformer returns a new index to that of X. It is as if you did `reset_index` upon X. This should fix that issue.